### PR TITLE
fix: provided `Inherits` macro as workaround for class conformance error in SwiftUI

### DIFF
--- a/.github/config/spellcheck-wordlist.txt
+++ b/.github/config/spellcheck-wordlist.txt
@@ -62,3 +62,5 @@ cocoapods
 DocumentationExtension
 mergeBehavior
 lowercasing
+SwiftData
+SwiftUI

--- a/Sources/MacroPlugin/Definitions.swift
+++ b/Sources/MacroPlugin/Definitions.swift
@@ -535,3 +535,40 @@ struct IgnoreCodingInitialized: PeerMacro {
         )
     }
 }
+
+/// Attribute type for `Inherits` macro-attribute.
+///
+/// This type can validate`Inherits` macro-attribute
+/// usage and extract data for `Codable` macro to
+/// generate implementation.
+///
+/// Attaching this macro to type allows indicating the generated
+/// `Codable` conformance whether a class already inheriting
+/// conformance from super class or not.
+struct Inherits: PeerMacro {
+    /// Provide metadata to `Codable` macro for final expansion
+    /// and verify proper usage of this macro.
+    ///
+    /// This macro doesn't perform any expansion rather `Codable` macro
+    /// uses when performing expansion.
+    ///
+    /// This macro verifies that macro usage condition is met by attached
+    /// declaration by using the `validate` implementation provided.
+    ///
+    /// - Parameters:
+    ///   - node: The attribute describing this macro.
+    ///   - declaration: The declaration this macro attribute is attached to.
+    ///   - context: The context in which to perform the macro expansion.
+    ///
+    /// - Returns: No declaration is returned, only attached declaration is
+    ///            analyzed.
+    static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        return try PluginCore.Inherits.expansion(
+            of: node, providingPeersOf: declaration, in: context
+        )
+    }
+}

--- a/Sources/MacroPlugin/Plugin.swift
+++ b/Sources/MacroPlugin/Plugin.swift
@@ -24,5 +24,6 @@ struct MetaCodablePlugin: CompilerPlugin {
         MemberInit.self,
         CodingKeys.self,
         IgnoreCodingInitialized.self,
+        Inherits.self,
     ]
 }

--- a/Sources/MetaCodable/Codable/Codable.swift
+++ b/Sources/MetaCodable/Codable/Codable.swift
@@ -58,3 +58,36 @@
 @available(swift 5.9)
 public macro Codable() =
     #externalMacro(module: "MacroPlugin", type: "Codable")
+
+/// Indicates whether super class conforms to `Codable` or not.
+///
+/// By default, ``Codable()`` assumes class inherits `Decodable`
+/// or `Encodable` conformance if it doesn't receive protocol needs
+/// to be conformed from the compiler. Using this macro, it can be explicitly
+/// indicated that the class doesn't inherit conformance in such cases.
+///
+/// Following code indicates ``Codable()`` that `Item` class doesn't
+/// inherit conformance:
+/// ```swift
+/// @Codable
+/// @Model
+/// @Inherits(decodable: false, encodable: false)
+/// final class Item {
+///     @CodedAt("timestamp")
+///     var timestamp: Date? = nil
+///
+///     init() { }
+/// }
+/// ```
+///
+/// - Parameters:
+///   - decodable: Whether super class conforms to `Decodable`.
+///   - encodable: Whether super class conforms to `Encodable`.
+///
+/// - Note: This macro on its own only validates if attached declaration
+///   is a class declaration. ``Codable()`` macro uses this macro
+///   when generating final implementations.
+@attached(peer)
+@available(swift 5.9)
+public macro Inherits(decodable: Bool, encodable: Bool) =
+    #externalMacro(module: "MacroPlugin", type: "Inherits")

--- a/Sources/MetaCodable/MetaCodable.docc/Limitations.md
+++ b/Sources/MetaCodable/MetaCodable.docc/Limitations.md
@@ -76,3 +76,9 @@ Due to these limitations, `Encodable` conformance isn't generated, users has to 
 ### Why MetaProtocolCodable plugin can't scan Xcode target dependencies?
 
 Currently Swift Package Manager always returns empty list for Xcode target dependencies as noted in [this bug](https://github.com/apple/swift-package-manager/issues/6003). Hence `MetaProtocolCodable` can currently only scan the files from the target or from the project including the target.
+
+### Why macro is breaking with SwiftData class?
+
+Currently during certain customization in SwiftUI, compiler is sending no protocol data to ``Codable()``. Due to this, ``Codable()`` tries to find `Codable` protocol implementation for the class. If no implementation found, ``Codable()`` assumes class inherits conformance from super class, and generates implementation accordingly causing issues like [#56](https://github.com/SwiftyLab/MetaCodable/issues/56).
+
+Until this is fixes from Swift compiler, ``Inherits(decodable:encodable:)`` macro can be used to indicate explicitly that class doesn't inherit `Codable` conformance.

--- a/Sources/MetaCodable/MetaCodable.docc/MetaCodable.md
+++ b/Sources/MetaCodable/MetaCodable.docc/MetaCodable.md
@@ -85,6 +85,7 @@ Supercharge `Swift`'s `Codable` implementations with macros.
 - ``IgnoreEncoding()``
 - ``CodingKeys(_:)``
 - ``IgnoreCodingInitialized()``
+- ``Inherits(decodable:encodable:)``
 
 ### Helpers
 

--- a/Sources/PluginCore/Attributes/Codable/Inherits.swift
+++ b/Sources/PluginCore/Attributes/Codable/Inherits.swift
@@ -1,0 +1,67 @@
+@_implementationOnly import SwiftSyntax
+
+/// Attribute type for `Inherits` macro-attribute.
+///
+/// This type can validate`Inherits` macro-attribute
+/// usage and extract data for `Codable` macro to
+/// generate implementation.
+///
+/// Attaching this macro to type allows indicating the generated
+/// `Codable` conformance whether a class already inheriting
+/// conformance from super class or not.
+package struct Inherits: PeerAttribute {
+    /// The node syntax provided
+    /// during initialization.
+    let node: AttributeSyntax
+
+    /// Whether super class conforms to `Decodable`.
+    ///
+    /// In case of no super class, this should be `false`.
+    var decodable: Bool {
+        return node.arguments?.as(LabeledExprListSyntax.self)?.first { expr in
+            expr.label?.tokenKind == .identifier("decodable")
+        }?.expression.as(BooleanLiteralExprSyntax.self)?.literal
+            .tokenKind == .keyword(.true)
+    }
+
+    /// Whether super class conforms to `Encodable`.
+    ///
+    /// In case of no super class, this should be `false`.
+    var encodable: Bool {
+        return node.arguments?.as(LabeledExprListSyntax.self)?.first { expr in
+            expr.label?.tokenKind == .identifier("encodable")
+        }?.expression.as(BooleanLiteralExprSyntax.self)?.literal
+            .tokenKind == .keyword(.true)
+    }
+
+    /// Creates a new instance with the provided node
+    ///
+    /// The initializer fails to create new instance if the name
+    /// of the provided node is different than this attribute.
+    ///
+    /// - Parameter node: The attribute syntax to create with.
+    /// - Returns: Newly created attribute instance.
+    init?(from node: AttributeSyntax) {
+        guard
+            node.attributeName.as(IdentifierTypeSyntax.self)!
+                .name.text == Self.name
+        else { return nil }
+        self.node = node
+    }
+
+    /// Builds diagnoser that can validate this macro
+    /// attached declaration.
+    ///
+    /// Builds diagnoser that validates attached declaration
+    /// is a class declaration, has `Codable` macro attached
+    /// and macro usage is not duplicated for the same declaration.
+    ///
+    /// - Returns: The built diagnoser instance.
+    func diagnoser() -> DiagnosticProducer {
+        return AggregatedDiagnosticProducer {
+            shouldNotDuplicate()
+            mustBeCombined(with: Codable.self)
+            expect(syntaxes: ClassDeclSyntax.self)
+        }
+    }
+}

--- a/Tests/MetaCodableTests/CodableInheritanceTests.swift
+++ b/Tests/MetaCodableTests/CodableInheritanceTests.swift
@@ -1,0 +1,185 @@
+#if SWIFT_SYNTAX_EXTENSION_MACRO_FIXED
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+@testable import PluginCore
+
+final class CodableInheritanceTests: XCTestCase {
+
+    func testMisuseOnNonClassDeclaration() throws {
+        assertMacroExpansion(
+            """
+            @Codable
+            @Inherits(decodable: false, encodable: false)
+            struct SomeCodable {
+                let value: String
+            }
+            """,
+            expandedSource:
+                """
+                struct SomeCodable {
+                    let value: String
+                }
+
+                extension SomeCodable: Decodable {
+                    init(from decoder: any Decoder) throws {
+                        let container = try decoder.container(keyedBy: CodingKeys.self)
+                        self.value = try container.decode(String.self, forKey: CodingKeys.value)
+                    }
+                }
+
+                extension SomeCodable: Encodable {
+                    func encode(to encoder: any Encoder) throws {
+                        var container = encoder.container(keyedBy: CodingKeys.self)
+                        try container.encode(self.value, forKey: CodingKeys.value)
+                    }
+                }
+
+                extension SomeCodable {
+                    enum CodingKeys: String, CodingKey {
+                        case value = "value"
+                    }
+                }
+                """,
+            diagnostics: [
+                .init(
+                    id: Inherits.misuseID,
+                    message:
+                        "@Inherits only applicable to class declarations",
+                    line: 2, column: 1,
+                    fixIts: [
+                        .init(message: "Remove @Inherits attribute")
+                    ]
+                )
+            ]
+        )
+    }
+
+    func testWithNoInheritance() throws {
+        assertMacroExpansion(
+            """
+            @Codable
+            @Inherits(decodable: false, encodable: false)
+            class SomeCodable {
+                var value: String = ""
+
+                init() { }
+            }
+            """,
+            expandedSource:
+                """
+                class SomeCodable {
+                    var value: String = ""
+
+                    init() { }
+
+                    required init(from decoder: any Decoder) throws {
+                        let container = try decoder.container(keyedBy: CodingKeys.self)
+                        self.value = try container.decode(String.self, forKey: CodingKeys.value)
+                    }
+
+                    func encode(to encoder: any Encoder) throws {
+                        var container = encoder.container(keyedBy: CodingKeys.self)
+                        try container.encode(self.value, forKey: CodingKeys.value)
+                    }
+
+                    enum CodingKeys: String, CodingKey {
+                        case value = "value"
+                    }
+                }
+
+                extension SomeCodable: Decodable {
+                }
+
+                extension SomeCodable: Encodable {
+                }
+                """,
+            conformsTo: []
+        )
+    }
+
+    func testWithExplicitInheritance() throws {
+        assertMacroExpansion(
+            """
+            @Codable
+            @Inherits(decodable: true, encodable: true)
+            class SomeCodable: SuperCodable {
+                var value: String = ""
+
+                init() { }
+            }
+            """,
+            expandedSource:
+                """
+                class SomeCodable: SuperCodable {
+                    var value: String = ""
+
+                    init() { }
+
+                    required init(from decoder: any Decoder) throws {
+                        let container = try decoder.container(keyedBy: CodingKeys.self)
+                        self.value = try container.decode(String.self, forKey: CodingKeys.value)
+                        try super.init(from: decoder)
+                    }
+
+                    override func encode(to encoder: any Encoder) throws {
+                        var container = encoder.container(keyedBy: CodingKeys.self)
+                        try container.encode(self.value, forKey: CodingKeys.value)
+                        try super.encode(to: encoder)
+                    }
+
+                    enum CodingKeys: String, CodingKey {
+                        case value = "value"
+                    }
+                }
+                """,
+            conformsTo: []
+        )
+    }
+
+    func testWithExplicitPartialInheritance() throws {
+        assertMacroExpansion(
+            """
+            @Codable
+            @Inherits(decodable: true, encodable: false)
+            class SomeCodable: SuperDecodable {
+                var value: String = ""
+
+                init() { }
+            }
+            """,
+            expandedSource:
+                """
+                class SomeCodable: SuperDecodable {
+                    var value: String = ""
+
+                    init() { }
+
+                    required init(from decoder: any Decoder) throws {
+                        let container = try decoder.container(keyedBy: CodingKeys.self)
+                        self.value = try container.decode(String.self, forKey: CodingKeys.value)
+                        try super.init(from: decoder)
+                    }
+
+                    func encode(to encoder: any Encoder) throws {
+                        var container = encoder.container(keyedBy: CodingKeys.self)
+                        try container.encode(self.value, forKey: CodingKeys.value)
+                    }
+
+                    enum CodingKeys: String, CodingKey {
+                        case value = "value"
+                    }
+                }
+
+                extension SomeCodable: Encodable {
+                }
+                """,
+            conformsTo: []
+        )
+    }
+}
+#endif

--- a/Tests/MetaCodableTests/CodableTests.swift
+++ b/Tests/MetaCodableTests/CodableTests.swift
@@ -326,6 +326,7 @@ let allMacros: [String: Macro.Type] = [
     "MemberInit": MacroPlugin.MemberInit.self,
     "CodingKeys": MacroPlugin.CodingKeys.self,
     "IgnoreCodingInitialized": MacroPlugin.IgnoreCodingInitialized.self,
+    "Inherits": MacroPlugin.Inherits.self
 ]
 #else
 let allMacros: [String: Macro.Type] = [
@@ -342,6 +343,7 @@ let allMacros: [String: Macro.Type] = [
     "MemberInit": MemberInit.self,
     "CodingKeys": CodingKeys.self,
     "IgnoreCodingInitialized": IgnoreCodingInitialized.self,
+    "Inherits": Inherits.self
 ]
 #endif
 


### PR DESCRIPTION
workaround for #56