### PR TITLE
Set default values ​​for mutable variables via initialization syntax.

### DIFF
--- a/Sources/PluginCore/Attributes/Default.swift
+++ b/Sources/PluginCore/Attributes/Default.swift
@@ -77,6 +77,26 @@ where
     }
 }
 
+extension Registration
+where
+Decl == PropertyDeclSyntax, Var: PropertyVariable & InitializableVariable, Var.Initialization == AnyRequiredVariableInitialization, Var == AnyPropertyVariable<AnyRequiredVariableInitialization>
+{
+    /// Update registration with binding initializer value. If the ``Default`` attribute is applied, it takes precedence.
+    ///
+    /// New registration is updated with default expression data that will be
+    /// used for decoding failure and memberwise initializer(s), if provided.
+    ///
+    /// - Returns: Newly built registration with default expression data or self.
+    func addDefaultValueIfInitializerExists() -> Self {
+        guard Default(from: self.decl) == nil, let value = decl.binding.initializer?.value, let variable = self.variable.base as? AnyPropertyVariable<RequiredInitialization> else {
+            return self
+        }
+        
+        let newVar = variable.with(default: value)
+        return self.updating(with: newVar.any)
+    }
+}
+
 fileprivate extension PropertyVariable
 where Initialization == RequiredInitialization {
     /// Update variable data with the default value expression provided.

--- a/Sources/PluginCore/Variables/Type/MemberGroup.swift
+++ b/Sources/PluginCore/Variables/Type/MemberGroup.swift
@@ -192,6 +192,7 @@ where Decl.ChildSyntaxInput == Void, Decl.MemberSyntax == PropertyDeclSyntax {
                 .useHelperCoderIfExists()
                 .checkForAlternateKeyValues(addTo: codingKeys, context: context)
                 .addDefaultValueIfExists()
+                .addDefaultValueIfInitializerExists()
                 .checkCanBeInitialized()
                 .checkCodingIgnored()
         }

--- a/Tests/MetaCodableTests/VariableDeclarationTests.swift
+++ b/Tests/MetaCodableTests/VariableDeclarationTests.swift
@@ -69,7 +69,11 @@ final class VariableDeclarationTests: XCTestCase {
                 extension SomeCodable: Decodable {
                     init(from decoder: any Decoder) throws {
                         let container = try decoder.container(keyedBy: CodingKeys.self)
-                        self.value = try container.decode(String.self, forKey: CodingKeys.value)
+                        do {
+                            self.value = try container.decodeIfPresent(String.self, forKey: CodingKeys.value) ?? "some"
+                        } catch {
+                            self.value = "some"
+                        }
                     }
                 }
 
@@ -308,8 +312,16 @@ final class VariableDeclarationTests: XCTestCase {
                 extension SomeCodable: Decodable {
                     init(from decoder: any Decoder) throws {
                         let container = try decoder.container(keyedBy: CodingKeys.self)
-                        self.value1 = try container.decode(String.self, forKey: CodingKeys.value1)
-                        self.value2 = try container.decode(String.self, forKey: CodingKeys.value2)
+                        do {
+                            self.value1 = try container.decodeIfPresent(String.self, forKey: CodingKeys.value1) ?? "some"
+                        } catch {
+                            self.value1 = "some"
+                        }
+                        do {
+                            self.value2 = try container.decodeIfPresent(String.self, forKey: CodingKeys.value2) ?? "some"
+                        } catch {
+                            self.value2 = "some"
+                        }
                     }
                 }
 


### PR DESCRIPTION
## 1. Mutable variables can have default values ​​added by adding initialization syntax. 
### We can get the default value whether it is a surface value or an expression from `binding.initializer?.value`. Like this:
```
var int1: Int = 10
var int2: Int = Int()
var ini3: Int = int1
```
`int1` default value is an integer literal. `int2` default value is a function expression. `int3` default value is a variable reference.
## 2. Usage: 
``` Swift
let globalVariable: Int = 0

@Codable
@MemberInit
struct Example {
    @Default(10)
    let int: Int   /// defaul value is 10
    var int2: Int = 10 /// default value is 10
    @Default(10)
    var int3: Int = 20 /// default value is 10 when apply `Default` attribute
    var int4: Int = 4, int5: Int = 5 /// `int4` default value is 4, `int5` default value is 5
    var int6: Int = globalVariable
}
```
## 3. The expanded results are as follows:
``` Swift
init(int: Int = 10) {
    self.int = int
}

init(int: Int = 10, int2: Int) {
    self.int = int
    self.int2 = int2
}

init(int: Int = 10, int3: Int) {
    self.int = int
    self.int3 = int3
}

init(int: Int = 10, int2: Int, int3: Int) {
    self.int = int
    self.int2 = int2
    self.int3 = int3
}

init(int: Int = 10, int4: Int) {
    self.int = int
    self.int4 = int4
}

init(int: Int = 10, int2: Int, int4: Int) {
    self.int = int
    self.int2 = int2
    self.int4 = int4
}

init(int: Int = 10, int3: Int, int4: Int) {
    self.int = int
    self.int3 = int3
    self.int4 = int4
}

init(int: Int = 10, int2: Int, int3: Int, int4: Int) {
    self.int = int
    self.int2 = int2
    self.int3 = int3
    self.int4 = int4
}

init(int: Int = 10, int5: Int) {
    self.int = int
    self.int5 = int5
}

init(int: Int = 10, int2: Int, int5: Int) {
    self.int = int
    self.int2 = int2
    self.int5 = int5
}

init(int: Int = 10, int3: Int, int5: Int) {
    self.int = int
    self.int3 = int3
    self.int5 = int5
}

init(int: Int = 10, int2: Int, int3: Int, int5: Int) {
    self.int = int
    self.int2 = int2
    self.int3 = int3
    self.int5 = int5
}

init(int: Int = 10, int4: Int, int5: Int) {
    self.int = int
    self.int4 = int4
    self.int5 = int5
}

init(int: Int = 10, int2: Int, int4: Int, int5: Int) {
    self.int = int
    self.int2 = int2
    self.int4 = int4
    self.int5 = int5
}

init(int: Int = 10, int3: Int, int4: Int, int5: Int) {
    self.int = int
    self.int3 = int3
    self.int4 = int4
    self.int5 = int5
}

init(int: Int = 10, int2: Int, int3: Int, int4: Int, int5: Int) {
    self.int = int
    self.int2 = int2
    self.int3 = int3
    self.int4 = int4
    self.int5 = int5
}

init(int: Int = 10, int6: Int) {
    self.int = int
    self.int6 = int6
}

init(int: Int = 10, int2: Int, int6: Int) {
    self.int = int
    self.int2 = int2
    self.int6 = int6
}

init(int: Int = 10, int3: Int, int6: Int) {
    self.int = int
    self.int3 = int3
    self.int6 = int6
}

init(int: Int = 10, int2: Int, int3: Int, int6: Int) {
    self.int = int
    self.int2 = int2
    self.int3 = int3
    self.int6 = int6
}

init(int: Int = 10, int4: Int, int6: Int) {
    self.int = int
    self.int4 = int4
    self.int6 = int6
}

init(int: Int = 10, int2: Int, int4: Int, int6: Int) {
    self.int = int
    self.int2 = int2
    self.int4 = int4
    self.int6 = int6
}

init(int: Int = 10, int3: Int, int4: Int, int6: Int) {
    self.int = int
    self.int3 = int3
    self.int4 = int4
    self.int6 = int6
}

init(int: Int = 10, int2: Int, int3: Int, int4: Int, int6: Int) {
    self.int = int
    self.int2 = int2
    self.int3 = int3
    self.int4 = int4
    self.int6 = int6
}

init(int: Int = 10, int5: Int, int6: Int) {
    self.int = int
    self.int5 = int5
    self.int6 = int6
}

init(int: Int = 10, int2: Int, int5: Int, int6: Int) {
    self.int = int
    self.int2 = int2
    self.int5 = int5
    self.int6 = int6
}

init(int: Int = 10, int3: Int, int5: Int, int6: Int) {
    self.int = int
    self.int3 = int3
    self.int5 = int5
    self.int6 = int6
}

init(int: Int = 10, int2: Int, int3: Int, int5: Int, int6: Int) {
    self.int = int
    self.int2 = int2
    self.int3 = int3
    self.int5 = int5
    self.int6 = int6
}

init(int: Int = 10, int4: Int, int5: Int, int6: Int) {
    self.int = int
    self.int4 = int4
    self.int5 = int5
    self.int6 = int6
}

init(int: Int = 10, int2: Int, int4: Int, int5: Int, int6: Int) {
    self.int = int
    self.int2 = int2
    self.int4 = int4
    self.int5 = int5
    self.int6 = int6
}

init(int: Int = 10, int3: Int, int4: Int, int5: Int, int6: Int) {
    self.int = int
    self.int3 = int3
    self.int4 = int4
    self.int5 = int5
    self.int6 = int6
}

init(int: Int = 10, int2: Int, int3: Int, int4: Int, int5: Int, int6: Int) {
    self.int = int
    self.int2 = int2
    self.int3 = int3
    self.int4 = int4
    self.int5 = int5
    self.int6 = int6
}

extension Example: Decodable {
    init(from decoder: any Decoder) throws {
        let container = try decoder.container(keyedBy: CodingKeys.self)
        do {
            self.int = try container.decodeIfPresent(Int.self, forKey: CodingKeys.int) ?? 10
        } catch {
            self.int = 10
        }
        do {
            self.int2 = try container.decodeIfPresent(Int.self, forKey: CodingKeys.int2) ?? 10 /// default value is 10
        } catch {
            self.int2 = 10 /// default value is 10
        }
        do {
            self.int3 = try container.decodeIfPresent(Int.self, forKey: CodingKeys.int3) ?? 10
        } catch {
            self.int3 = 10
        }
        do {
            self.int4 = try container.decodeIfPresent(Int.self, forKey: CodingKeys.int4) ?? 4
        } catch {
            self.int4 = 4
        }
        do {
            self.int5 = try container.decodeIfPresent(Int.self, forKey: CodingKeys.int5) ?? 5 /// `int4` default value is 4, `int5` default value is 5
        } catch {
            self.int5 = 5 /// `int4` default value is 4, `int5` default value is 5
        }
        do {
            self.int6 = try container.decodeIfPresent(Int.self, forKey: CodingKeys.int6) ?? globalVariable
        } catch {
            self.int6 = globalVariable
        }
    }
}

extension Example: Encodable {
    func encode(to encoder: any Encoder) throws {
        var container = encoder.container(keyedBy: CodingKeys.self)
        try container.encode(self.int, forKey: CodingKeys.int)
        try container.encode(self.int2, forKey: CodingKeys.int2)
        try container.encode(self.int3, forKey: CodingKeys.int3)
        try container.encode(self.int4, forKey: CodingKeys.int4)
        try container.encode(self.int5, forKey: CodingKeys.int5)
        try container.encode(self.int6, forKey: CodingKeys.int6)
    }
}

extension Example {
    enum CodingKeys: String, CodingKey {
        case int = "int"
        case int2 = "int2"
        case int3 = "int3"
        case int4 = "int4"
        case int5 = "int5"
        case int6 = "int6"
    }
}
```
### As expected except there are too many initialization methods. But the next step can be to just generate an initializing constructor containing all parameters with default values.
