### PR TITLE
feat: subtract the untested prerelease version of swift syntax from the supporting range

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .plugin(name: "MetaProtocolCodable", targets: ["MetaProtocolCodable"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.1.0"..<"601.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", "509.1.0"..<"601.0.0-prerelease"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.4"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.2"),
         .package(url: "https://github.com/swiftlang/swift-format", from: "509.0.0"),


### PR DESCRIPTION
It is not recommended to include the prerelease versions in the range