### PR TITLE
fix: Attempt to work around PackagePlugin.Path deprecation

### DIFF
--- a/Plugins/MetaProtocolCodable/PluginContext.swift
+++ b/Plugins/MetaProtocolCodable/PluginContext.swift
@@ -1,4 +1,5 @@
 import PackagePlugin
+import Foundation
 
 /// Provides information about the package for which the plugin is invoked,
 /// as well as contextual information based on the plugin's stated intent
@@ -24,6 +25,8 @@ protocol MetaProtocolCodablePluginContext {
     /// directories for cache files and other file system content that either
     /// it or the command will need.
     var pluginWorkDirectory: Path { get }
+    var pluginWorkDirectoryURL: URL { get }
+    
     /// The targets which are local to current context.
     ///
     /// These targets are included in the same package/project as this context.


### PR DESCRIPTION
Currently, the build of this package (and dependees) produces a number of warnings like:

```
warning: 'appending' is deprecated: Use `URL` type instead of `Path`.
 51 | 
 52 |         // Setup folder
 53 |         let genFolder = context.pluginWorkDirectory.appending(["ProtocolGen"])
    |                                                     `- warning: 'appending' is deprecated: Use `URL` type instead of `Path`.
 54 |         try FileManager.default.createDirectory(
 55 |             atPath: genFolder.string, withIntermediateDirectories: true
```

This (to my understanding) is because the type `PackagePlugin.Path` is deprecated in favor of `Foundation.URL`, but the replacements accessor properties are not universally implemented until (I think) version 6.1.

In this PR, I'm attempting to remove these warnings. In `Plugin.swift` this is relatively straightforward, but in `SwiftPackageTarget.swift` it's a bit tricky:

The procotol `SourceModuleTarget` does not currently include the needed `var directoryURL: URL`, even though both (and I think those are the only two types that conform to this protocol) `ClangSourceModuleTarget` and `SwiftSourceModuleTarget` have this property. I'm adding here a workaround that tries to downcast the incoming `SourceModuleTarget` to either of these types, and then packages it in a temporary helper protocol `CompatSourceModuleTarget` that exposes the `directoryURL` property.


I'm not sure if this is the best way to this, but I thought I'd open a PR to discuss it. I can't run the tests included in the repo (even on `main` they fail for me), so I don't know if the changes are fully correct, aside from compiling without warnings.

Let me know what you think!