### PR TITLE
Update to swift-syntax 601.0.1

### DIFF
--- a/Sources/PluginCore/Attributes/CodedAs.swift
+++ b/Sources/PluginCore/Attributes/CodedAs.swift
@@ -23,9 +23,13 @@ package struct CodedAs: PropertyAttribute {
     /// Used for enums with internal/adjacent tagging to decode
     /// the identifier to this type.
     var type: TypeSyntax? {
+        #if canImport(SwiftSyntax601)
         return node.attributeName.as(IdentifierTypeSyntax.self)?
-            .genericArgumentClause?.arguments
-            .first?.argument.as(TypeSyntax.self)
+            .genericArgumentClause?.arguments.first?.argument.as(TypeSyntax.self)
+        #else
+        return node.attributeName.as(IdentifierTypeSyntax.self)?
+            .genericArgumentClause?.arguments.first?.argument
+        #endif
     }
 
     /// Creates a new instance with the provided node.

--- a/Sources/PluginCore/Variables/Property/PropertyVariable.swift
+++ b/Sources/PluginCore/Variables/Property/PropertyVariable.swift
@@ -151,6 +151,7 @@ extension PropertyVariable {
     func codingTypeMethod(
         forMethod method: ExprSyntax
     ) -> (TypeSyntax, ExprSyntax) {
+        #if canImport(SwiftSyntax601)
         let (dType, dMethod): (TypeSyntax, ExprSyntax)
         if let type = type.as(OptionalTypeSyntax.self) {
             dType = type.wrappedType
@@ -172,6 +173,29 @@ extension PropertyVariable {
             dMethod = method
         }
         return (dType, dMethod)
+        #else
+        let (dType, dMethod): (TypeSyntax, ExprSyntax)
+        if let type = type.as(OptionalTypeSyntax.self) {
+            dType = type.wrappedType
+            dMethod = "\(method)IfPresent"
+        } else if let type = type.as(ImplicitlyUnwrappedOptionalTypeSyntax.self)
+        {
+            dType = type.wrappedType
+            dMethod = "\(method)IfPresent"
+        } else if let type = type.as(IdentifierTypeSyntax.self),
+            type.name.text == "Optional",
+            let gArgs = type.genericArgumentClause?.arguments,
+            gArgs.count == 1,
+            let type = gArgs.first?.argument
+        {
+            dType = type
+            dMethod = "\(method)IfPresent"
+        } else {
+            dType = type
+            dMethod = method
+        }
+        return (dType, dMethod)
+        #endif
     }
 }
 


### PR DESCRIPTION
This PR updates `swift-syntax` to version 601.0.1 and fixes the issue of not being able to match Swift 5, where the original `Package@swift-5.swift` was not a valid package name, resulting in the use of Swift 6 configuration files.