### PR TITLE
feat: added common strategies applicable to all properties

### DIFF
--- a/Examples/App/Sources/ContentView.swift
+++ b/Examples/App/Sources/ContentView.swift
@@ -1,6 +1,6 @@
-import SwiftUI
-import MetaCodable
 import HelperCoders
+import MetaCodable
+import SwiftUI
 
 public struct ContentView: View {
     public init() {}

--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,9 @@
 // swift-tools-version: 6.0
+// swift-format-ignore-file
 
+import CompilerPluginSupport
 import Foundation
 import PackageDescription
-import CompilerPluginSupport
 
 let package = Package(
     name: "MetaCodable",

--- a/Package@swift-5.swift
+++ b/Package@swift-5.swift
@@ -1,8 +1,9 @@
 // swift-tools-version: 5.9
+// swift-format-ignore-file
 
+import CompilerPluginSupport
 import Foundation
 import PackageDescription
-import CompilerPluginSupport
 
 let package = Package(
     name: "MetaCodable",

--- a/Sources/HelperCoders/HelperCoders.docc/HelperCoders.md
+++ b/Sources/HelperCoders/HelperCoders.docc/HelperCoders.md
@@ -75,3 +75,7 @@ Level up `MetaCodable`'s generated implementations with helpers assisting common
 ### Sequence
 
 - ``SequenceCoder``
+
+### Strategies
+
+- ``HelperCoderStrategy``

--- a/Sources/HelperCoders/Strategies/HelperCoderStrategy.swift
+++ b/Sources/HelperCoders/Strategies/HelperCoderStrategy.swift
@@ -1,0 +1,21 @@
+import MetaCodable
+
+/// An enumeration of supported helper coder strategies for use with the `@Codable` macro's `commonStrategies` parameter.
+///
+/// Use cases such as `.valueCoder()` allow you to specify that all properties should use a particular value coding strategy
+/// (e.g., `ValueCoder`) for encoding and decoding, without annotating each property individually.
+public enum HelperCoderStrategy {
+    /// Applies the `ValueCoder` strategy to all properties, optionally specifying additional types.
+    case valueCoder(_ additionalTypes: [any ValueCodingStrategy.Type] = [])
+    // Future cases can be added here
+}
+
+public extension CodableCommonStrategy {
+    /// Returns a `CodableCommonStrategy` representing the use of a helper coder strategy for all properties.
+    ///
+    /// - Parameter helperCoderStrategy: The helper coder strategy to apply (e.g., `.valueCoder()`).
+    /// - Returns: A `CodableCommonStrategy` value for use in the `commonStrategies` parameter of `@Codable`.
+    static func codedBy(_ helperCoderStrategy: HelperCoderStrategy) -> Self {
+        return .init()
+    }
+}

--- a/Sources/MetaCodable/Codable/Codable.swift
+++ b/Sources/MetaCodable/Codable/Codable.swift
@@ -46,6 +46,10 @@
 ///   * If attached declaration already conforms to `Codable` this macro expansion
 ///     is skipped.
 ///
+/// - Parameters:
+///   - commonStrategies: An array of CodableCommonStrategy values specifying
+///   type conversion strategies to be automatically applied to all properties of the type.
+///
 /// - Important: The attached declaration must be of a `struct`, `class`, `enum`
 ///   or `actor` type. [See the limitations for this macro](<doc:Limitations>).
 @attached(
@@ -58,7 +62,7 @@
     names: named(CodingKeys), named(init(from:)), named(encode(to:))
 )
 @available(swift 5.9)
-public macro Codable() =
+public macro Codable(commonStrategies: [CodableCommonStrategy] = []) =
     #externalMacro(module: "MacroPlugin", type: "Codable")
 
 /// Indicates whether super class conforms to `Codable` or not.

--- a/Sources/MetaCodable/Codable/CodableCommonStrategy.swift
+++ b/Sources/MetaCodable/Codable/CodableCommonStrategy.swift
@@ -1,0 +1,23 @@
+// CodableCommonStrategy.swift
+// Defines the CodableCommonStrategy struct for commonStrategies parameter in @Codable macro.
+
+/// A marker type used to represent a common type conversion strategy for the `@Codable` macro.
+///
+/// `CodableCommonStrategy` is used as the element type for the `commonStrategies` parameter in the
+/// `@Codable` macro. It allows users to specify strategies (such as value coding) that should be
+/// automatically applied to all properties of a type, so that users do not have to annotate each property
+/// individually. The macro system interprets these strategies and injects the appropriate coding logic
+/// during macro expansion.
+///
+/// Example usage:
+/// ```swift
+/// @Codable(commonStrategies: [.codedBy(.valueCoder())])
+/// struct MyModel {
+///     let int: Int
+///     let string: String
+/// }
+/// ```
+public struct CodableCommonStrategy {
+    // Only allow MetaCodable to construct
+    package init() {}
+}

--- a/Sources/MetaCodable/MetaCodable.docc/MetaCodable.md
+++ b/Sources/MetaCodable/MetaCodable.docc/MetaCodable.md
@@ -68,7 +68,7 @@ Supercharge `Swift`'s `Codable` implementations with macros.
 
 ### Macros
 
-- ``Codable()``
+- ``Codable(commonStrategies:)``
 - ``MemberInit()``
 
 ### Strategies
@@ -81,6 +81,7 @@ Supercharge `Swift`'s `Codable` implementations with macros.
 - ``UnTagged()``
 - ``CodingKeys(_:)``
 - ``Inherits(decodable:encodable:)``
+- ``CodableCommonStrategy``
 
 ### Helpers
 

--- a/Sources/PluginCore/Attributes/Codable/Codable.swift
+++ b/Sources/PluginCore/Attributes/Codable/Codable.swift
@@ -16,7 +16,7 @@ import SwiftSyntax
 ///     methods.
 ///   * If attached declaration already conforms to `Codable` this macro expansion
 ///     is skipped.
-package struct Codable: Attribute {
+package struct Codable: PeerAttribute {
     /// The node syntax provided
     /// during initialization.
     let node: AttributeSyntax

--- a/Sources/PluginCore/Attributes/Codable/Strategies/StrategyFinder.swift
+++ b/Sources/PluginCore/Attributes/Codable/Strategies/StrategyFinder.swift
@@ -1,0 +1,100 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Finds and stores common strategies from a type declaration's macro attributes.
+///
+/// This struct parses the macro attributes on a type declaration to extract any
+/// common type conversion strategies (such as value coding strategies) that should
+/// be applied to all properties. The extracted strategies can then be used to
+/// automatically transform property registrations during macro expansion.
+struct StrategyFinder {
+    /// The list of value coding strategies (as type names) to apply to properties.
+    let valueCodingStrategies: [TokenSyntax]
+    // Extend with more strategies as needed
+
+    /// Initializes a new `StrategyFinder` by parsing the macro attributes of the given declaration.
+    ///
+    /// - Parameter decl: The declaration to extract strategies from.
+    init(decl: some AttributableDeclSyntax) {
+        guard
+            let attr = Codable(from: decl),
+            let arguments = attr.node.arguments?.as(LabeledExprListSyntax.self),
+            let arg = arguments.first(where: {
+                $0.label?.text == "commonStrategies"
+            }),
+            let expr = arg.expression.as(ArrayExprSyntax.self)
+        else {
+            self.valueCodingStrategies = []
+            return
+        }
+
+        let codedBys = expr.elements.lazy
+            .compactMap({ $0.expression.as(FunctionCallExprSyntax.self) })
+            .filter({
+                $0.calledExpression.as(MemberAccessExprSyntax.self)?.declName
+                    .baseName.text == "codedBy"
+            })
+        let valueCoders = codedBys.flatMap({
+            $0.arguments
+                .compactMap({ $0.expression.as(FunctionCallExprSyntax.self) })
+                .filter({
+                    $0.calledExpression.as(MemberAccessExprSyntax.self)?
+                        .declName.baseName.text == "valueCoder"
+                })
+        })
+
+        var valueCodingStrategies: [TokenSyntax] = []
+        if !valueCoders.isEmpty {
+            // Default strategies for primitive types
+            valueCodingStrategies = [
+                "Bool", "Double", "Float", "String",
+                "Int", "Int8", "Int16", "Int32", "Int64",
+                "UInt", "UInt8", "UInt16", "UInt32", "UInt64",
+            ]
+            // Add any additional types specified in valueCoder(...)
+            valueCodingStrategies.append(
+                contentsOf: valueCoders.flatMap {
+                    $0.arguments.first?.expression.as(ArrayExprSyntax.self)?
+                        .elements.compactMap {
+                            $0.expression.as(MemberAccessExprSyntax.self)?.base?
+                                .as(DeclReferenceExprSyntax.self)?.baseName
+                        } ?? []
+                }
+            )
+        }
+        self.valueCodingStrategies = valueCodingStrategies
+    }
+}
+
+extension Registration where Var: DefaultPropertyVariable {
+    /// Applies common strategies (such as value coding) to the property registration if the type declaration specifies them.
+    ///
+    /// This method uses `StrategyFinder` to extract any common strategies (e.g., value coding strategies)
+    /// from the macro attributes of the provided type declaration. If the property's type matches one of the
+    /// strategies, it wraps the property in a `HelperCodedVariable` using the appropriate helper (such as `ValueCoder`).
+    ///
+    /// - Parameter decl: The type declaration to extract strategies from.
+    /// - Returns: A new registration, possibly wrapping the property variable with a strategy-based helper.
+    func detectCommonStrategies(
+        from decl: some AttributableDeclSyntax
+    ) -> Registration<Decl, Key, StrategyVariable<Var.Initialization>> {
+        let finder = StrategyFinder(decl: decl)
+        let inStrategy =
+            finder.valueCodingStrategies.first { strategy in
+                strategy.trimmedDescription
+                    == self.variable.type.trimmedDescription
+            } != nil
+
+        let newVariable: AnyPropertyVariable<Var.Initialization>
+        if inStrategy {
+            newVariable =
+                HelperCodedVariable(
+                    base: self.variable,
+                    options: .helper("ValueCoder<\(variable.type)>()")
+                ).any
+        } else {
+            newVariable = self.variable.any
+        }
+        return self.updating(with: StrategyVariable(base: newVariable))
+    }
+}

--- a/Sources/PluginCore/Variables/Property/StrategyVariable.swift
+++ b/Sources/PluginCore/Variables/Property/StrategyVariable.swift
@@ -1,0 +1,132 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// A `PropertyVariable` that wraps another `PropertyVariable`, allowing strategy-based transformation.
+///
+/// This type is used to apply strategy-based transformations (such as value coding)
+/// to property variables during macro expansion, by wrapping the original variable
+/// and forwarding all protocol requirements.
+struct StrategyVariable<Initialization>: PropertyVariable
+where Initialization: VariableInitialization {
+    /// The wrapped property variable.
+    let base: AnyPropertyVariable<Initialization>
+
+    /// The name of the variable.
+    ///
+    /// Provides name of the underlying variable value.
+    var name: TokenSyntax { base.name }
+    /// The type of the variable.
+    ///
+    /// Provides type of the underlying variable value.
+    var type: TypeSyntax { base.type }
+    /// The value of the variable.
+    ///
+    /// Provides value of the underlying variable value.
+    var value: ExprSyntax? { base.value }
+
+    /// The prefix token to use along with `name` when decoding.
+    ///
+    /// Provides underlying variable value decode prefix.
+    var decodePrefix: TokenSyntax { base.decodePrefix }
+    /// The prefix token to use along with `name` when encoding.
+    ///
+    /// Provides underlying variable value encode prefix.
+    var encodePrefix: TokenSyntax { base.encodePrefix }
+
+    /// Whether the variable is to be decoded.
+    ///
+    /// Provides whether underlying variable value
+    /// is to be decoded.
+    var decode: Bool? { base.decode }
+    /// Whether the variable is to be encoded.
+    ///
+    /// Provides whether underlying variable value
+    /// is to be encoded.
+    var encode: Bool? { base.encode }
+
+    /// Whether the variable type requires `Decodable` conformance.
+    ///
+    /// Provides whether underlying variable type requires
+    /// `Decodable` conformance.
+    var requireDecodable: Bool? { base.requireDecodable }
+    /// Whether the variable type requires `Encodable` conformance.
+    ///
+    /// Provides whether underlying variable type requires
+    /// `Encodable` conformance.
+    var requireEncodable: Bool? { base.requireEncodable }
+
+    /// The fallback behavior when decoding fails.
+    ///
+    /// In the event this decoding this variable is failed,
+    /// appropriate fallback would be applied.
+    ///
+    /// Provides fallback for the underlying variable value.
+    var decodingFallback: DecodingFallback { base.decodingFallback }
+
+    /// Indicates the initialization type for this variable.
+    ///
+    /// Provides initialization type of the underlying variable value.
+    ///
+    /// - Parameter context: The context in which to perform
+    ///                      the macro expansion.
+    /// - Returns: The type of initialization for variable.
+    func initializing(
+        in context: some MacroExpansionContext
+    ) -> Initialization {
+        return base.initializing(in: context)
+    }
+
+    /// Provides the code syntax for decoding this variable
+    /// at the provided location.
+    ///
+    /// Provides code syntax for decoding of the underlying
+    /// variable value.
+    ///
+    /// - Parameters:
+    ///   - context: The context in which to perform the macro expansion.
+    ///   - location: The decoding location for the variable.
+    ///
+    /// - Returns: The generated variable decoding code.
+    func decoding(
+        in context: some MacroExpansionContext,
+        from location: PropertyCodingLocation
+    ) -> CodeBlockItemListSyntax {
+        return base.decoding(in: context, from: location)
+    }
+
+    /// Provides the code syntax for encoding this variable
+    /// at the provided location.
+    ///
+    /// Provides code syntax for encoding of the underlying
+    /// variable value.
+    ///
+    /// - Parameters:
+    ///   - context: The context in which to perform the macro expansion.
+    ///   - location: The encoding location for the variable.
+    ///
+    /// - Returns: The generated variable encoding code.
+    func encoding(
+        in context: some MacroExpansionContext,
+        to location: PropertyCodingLocation
+    ) -> CodeBlockItemListSyntax {
+        return base.encoding(in: context, to: location)
+    }
+
+    /// The number of variables this variable depends on.
+    ///
+    /// Provides the number of variables underlying variable depends on.
+    var dependenciesCount: UInt { base.dependenciesCount }
+
+    /// Checks whether this variable is dependent on the provided variable.
+    ///
+    /// Provides whether provided variable needs to be decoded first,
+    /// before decoding underlying variable value.
+    ///
+    /// - Parameter variable: The variable to check for.
+    /// - Returns: Whether this variable is dependent on the provided variable.
+    func depends<Variable: PropertyVariable>(on variable: Variable) -> Bool {
+        return base.depends(on: variable)
+    }
+}
+
+extension StrategyVariable: DefaultPropertyVariable {}

--- a/Sources/PluginCore/Variables/Type/MemberGroup.swift
+++ b/Sources/PluginCore/Variables/Type/MemberGroup.swift
@@ -195,6 +195,7 @@ where Decl.ChildSyntaxInput == Void, Decl.MemberSyntax == PropertyDeclSyntax {
                     provider: CodedAt(from: input.decl)
                         ?? CodedIn(from: input.decl) ?? CodedIn()
                 )
+                .detectCommonStrategies(from: decl)
                 .useHelperCoderIfExists()
                 .checkForAlternateKeyValues(addTo: codingKeys, context: context)
                 .addDefaultValueIfExists()

--- a/Tests/MetaCodableTests/Codable/CommonStrategiesValueCoderTests.swift
+++ b/Tests/MetaCodableTests/Codable/CommonStrategiesValueCoderTests.swift
@@ -1,0 +1,394 @@
+import Foundation
+import HelperCoders
+import MetaCodable
+import Testing
+
+// Test for @Codable(commonStrategies: [.codedBy(.valueCoder())])
+struct CommonStrategiesValueCoderTests {
+    @Codable(commonStrategies: [.codedBy(.valueCoder())])
+    struct Model {
+        let bool: Bool
+        let int: Int
+        let double: Double
+        let string: String
+    }
+
+    @Test
+    func testParsing() throws {
+        let json = """
+            {
+                "bool": "true",
+                "int": "42",
+                "double": "3.1416",
+                "string": 5265762156
+            }
+            """
+
+        let jsonData = try #require(json.data(using: .utf8))
+        let decoder = JSONDecoder()
+        let model = try decoder.decode(Model.self, from: jsonData)
+
+        #expect(model.bool)
+        #expect(model.int == 42)
+        #expect(model.double == 3.1416)
+        #expect(model.string == "5265762156")
+
+        // Test that encoding works too
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let encoded = try encoder.encode(model)
+        let reDecoded = try decoder.decode(Model.self, from: encoded)
+        #expect(reDecoded.bool)
+        #expect(reDecoded.int == 42)
+        #expect(reDecoded.double == 3.1416)
+        #expect(reDecoded.string == "5265762156")
+    }
+
+    @Test
+    func expansion() throws {
+        assertMacroExpansion(
+            """
+            @Codable(commonStrategies: [.codedBy(.valueCoder())])
+            struct Model {
+                let bool: Bool
+                let int: Int
+                let double: Double
+                let string: String
+            }
+            """,
+            expandedSource:
+                """
+                struct Model {
+                    let bool: Bool
+                    let int: Int
+                    let double: Double
+                    let string: String
+                }
+
+                extension Model: Decodable {
+                    init(from decoder: any Decoder) throws {
+                        let container = try decoder.container(keyedBy: CodingKeys.self)
+                        self.bool = try ValueCoder<Bool>().decode(from: container, forKey: CodingKeys.bool)
+                        self.int = try ValueCoder<Int>().decode(from: container, forKey: CodingKeys.int)
+                        self.double = try ValueCoder<Double>().decode(from: container, forKey: CodingKeys.double)
+                        self.string = try ValueCoder<String>().decode(from: container, forKey: CodingKeys.string)
+                    }
+                }
+
+                extension Model: Encodable {
+                    func encode(to encoder: any Encoder) throws {
+                        var container = encoder.container(keyedBy: CodingKeys.self)
+                        try ValueCoder<Bool>().encode(self.bool, to: &container, atKey: CodingKeys.bool)
+                        try ValueCoder<Int>().encode(self.int, to: &container, atKey: CodingKeys.int)
+                        try ValueCoder<Double>().encode(self.double, to: &container, atKey: CodingKeys.double)
+                        try ValueCoder<String>().encode(self.string, to: &container, atKey: CodingKeys.string)
+                    }
+                }
+
+                extension Model {
+                    enum CodingKeys: String, CodingKey {
+                        case bool = "bool"
+                        case int = "int"
+                        case double = "double"
+                        case string = "string"
+                    }
+                }
+                """
+        )
+    }
+
+    // Test 1: Properties that don't conform to ValueCodingStrategy
+    struct NonConformingTypes {
+        @Codable(commonStrategies: [.codedBy(.valueCoder())])
+        struct Model {
+            // Should use the built-in ValueCoder for Int
+            let number: Int
+            // URL does not conform to ValueCodingStrategy, so should be encoded/decoded normally
+            let url: URL
+            // UUID conforms to Codable but not to ValueCodingStrategy, so should be encoded/decoded normally
+            let identifier: UUID
+        }
+
+        @Test
+        func testNonConformingTypes() throws {
+            let json = """
+                {
+                    "number": "42",
+                    "url": "https://example.com",
+                    "identifier": "123e4567-e89b-12d3-a456-426614174000"
+                }
+                """
+
+            let jsonData = try #require(json.data(using: .utf8))
+            let decoder = JSONDecoder()
+            let model = try decoder.decode(Model.self, from: jsonData)
+
+            #expect(model.number == 42)
+            #expect(model.url == URL(string: "https://example.com"))
+            #expect(
+                model.identifier
+                    == UUID(uuidString: "123e4567-e89b-12d3-a456-426614174000")
+            )
+
+            // Test that encoding works too
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .sortedKeys
+            let encoded = try encoder.encode(model)
+            let reDecoded = try decoder.decode(Model.self, from: encoded)
+
+            #expect(reDecoded.number == 42)
+            #expect(reDecoded.url == URL(string: "https://example.com"))
+            #expect(
+                reDecoded.identifier
+                    == UUID(uuidString: "123e4567-e89b-12d3-a456-426614174000")
+            )
+        }
+
+        @Test
+        func expansion() throws {
+            assertMacroExpansion(
+                """
+                @Codable(commonStrategies: [.codedBy(.valueCoder())])
+                struct Model {
+                    let number: Int
+                    let url: URL
+                    let identifier: UUID
+                }
+                """,
+                expandedSource:
+                    """
+                    struct Model {
+                        let number: Int
+                        let url: URL
+                        let identifier: UUID
+                    }
+
+                    extension Model: Decodable {
+                        init(from decoder: any Decoder) throws {
+                            let container = try decoder.container(keyedBy: CodingKeys.self)
+                            self.number = try ValueCoder<Int>().decode(from: container, forKey: CodingKeys.number)
+                            self.url = try container.decode(URL.self, forKey: CodingKeys.url)
+                            self.identifier = try container.decode(UUID.self, forKey: CodingKeys.identifier)
+                        }
+                    }
+
+                    extension Model: Encodable {
+                        func encode(to encoder: any Encoder) throws {
+                            var container = encoder.container(keyedBy: CodingKeys.self)
+                            try ValueCoder<Int>().encode(self.number, to: &container, atKey: CodingKeys.number)
+                            try container.encode(self.url, forKey: CodingKeys.url)
+                            try container.encode(self.identifier, forKey: CodingKeys.identifier)
+                        }
+                    }
+
+                    extension Model {
+                        enum CodingKeys: String, CodingKey {
+                            case number = "number"
+                            case url = "url"
+                            case identifier = "identifier"
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    // Test 2: Custom types conforming to ValueCodingStrategy
+    struct CustomStrategies {
+        @Codable(commonStrategies: [.codedBy(.valueCoder([CGFloat.self]))])
+        struct Model {
+            // Should use standard String
+            let text: String
+            // Should use CGFloat
+            let number: CGFloat
+            // Should use standard String
+            let plainText: String
+        }
+
+        @Test
+        func testCustomStrategies() throws {
+            let json = """
+                {
+                    "text": "hello",
+                    "number": 21,
+                    "plainText": "unchanged"
+                }
+                """
+
+            let jsonData = try #require(json.data(using: .utf8))
+            let decoder = JSONDecoder()
+            let model = try decoder.decode(Model.self, from: jsonData)
+
+            #expect(model.text == "hello")
+            #expect(model.number == 21)
+            #expect(model.plainText == "unchanged")
+
+            // Test encoding
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .sortedKeys
+            let encoded = try String(
+                data: encoder.encode(model), encoding: .utf8
+            )
+
+            #expect(
+                encoded
+                    == #"{"number":21,"plainText":"unchanged","text":"hello"}"#
+            )
+        }
+
+        @Test
+        func expansion() throws {
+            assertMacroExpansion(
+                """
+                @Codable(commonStrategies: [.codedBy(.valueCoder([CGFloat.self]))])
+                struct Model {
+                    let text: String
+                    let number: CGFloat
+                    let plainText: String
+                }
+                """,
+                expandedSource:
+                    """
+                    struct Model {
+                        let text: String
+                        let number: CGFloat
+                        let plainText: String
+                    }
+
+                    extension Model: Decodable {
+                        init(from decoder: any Decoder) throws {
+                            let container = try decoder.container(keyedBy: CodingKeys.self)
+                            self.text = try ValueCoder<String>().decode(from: container, forKey: CodingKeys.text)
+                            self.number = try ValueCoder<CGFloat>().decode(from: container, forKey: CodingKeys.number)
+                            self.plainText = try ValueCoder<String>().decode(from: container, forKey: CodingKeys.plainText)
+                        }
+                    }
+
+                    extension Model: Encodable {
+                        func encode(to encoder: any Encoder) throws {
+                            var container = encoder.container(keyedBy: CodingKeys.self)
+                            try ValueCoder<String>().encode(self.text, to: &container, atKey: CodingKeys.text)
+                            try ValueCoder<CGFloat>().encode(self.number, to: &container, atKey: CodingKeys.number)
+                            try ValueCoder<String>().encode(self.plainText, to: &container, atKey: CodingKeys.plainText)
+                        }
+                    }
+
+                    extension Model {
+                        enum CodingKeys: String, CodingKey {
+                            case text = "text"
+                            case number = "number"
+                            case plainText = "plainText"
+                        }
+                    }
+                    """
+            )
+        }
+    }
+
+    // Test 3: Empty commonStrategies array
+    struct EmptyStrategies {
+        @Codable(commonStrategies: [])
+        struct Model {
+            let bool: Bool
+            let int: Int
+            let double: Double
+            let string: String
+        }
+
+        @Test
+        func testEmptyStrategies() throws {
+            let json = """
+                {
+                    "bool": true,
+                    "int": 42,
+                    "double": 3.14,
+                    "string": "test"
+                }
+                """
+
+            let jsonData = try #require(json.data(using: .utf8))
+            let decoder = JSONDecoder()
+            let model = try decoder.decode(Model.self, from: jsonData)
+
+            #expect(model.bool == true)
+            #expect(model.int == 42)
+            #expect(model.double == 3.14)
+            #expect(model.string == "test")
+
+            // Test that encoding works too
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .sortedKeys
+            let encoded = try String(
+                data: encoder.encode(model), encoding: .utf8
+            )
+            #expect(
+                encoded
+                    == #"{"bool":true,"double":3.14,"int":42,"string":"test"}"#
+            )
+        }
+
+        @Test
+        func expansion() throws {
+            assertMacroExpansion(
+                """
+                @Codable(commonStrategies: [])
+                struct Model {
+                    let bool: Bool
+                    let int: Int
+                    let double: Double
+                    let string: String
+                }
+                """,
+                expandedSource:
+                    """
+                    struct Model {
+                        let bool: Bool
+                        let int: Int
+                        let double: Double
+                        let string: String
+                    }
+
+                    extension Model: Decodable {
+                        init(from decoder: any Decoder) throws {
+                            let container = try decoder.container(keyedBy: CodingKeys.self)
+                            self.bool = try container.decode(Bool.self, forKey: CodingKeys.bool)
+                            self.int = try container.decode(Int.self, forKey: CodingKeys.int)
+                            self.double = try container.decode(Double.self, forKey: CodingKeys.double)
+                            self.string = try container.decode(String.self, forKey: CodingKeys.string)
+                        }
+                    }
+
+                    extension Model: Encodable {
+                        func encode(to encoder: any Encoder) throws {
+                            var container = encoder.container(keyedBy: CodingKeys.self)
+                            try container.encode(self.bool, forKey: CodingKeys.bool)
+                            try container.encode(self.int, forKey: CodingKeys.int)
+                            try container.encode(self.double, forKey: CodingKeys.double)
+                            try container.encode(self.string, forKey: CodingKeys.string)
+                        }
+                    }
+
+                    extension Model {
+                        enum CodingKeys: String, CodingKey {
+                            case bool = "bool"
+                            case int = "int"
+                            case double = "double"
+                            case string = "string"
+                        }
+                    }
+                    """
+            )
+        }
+    }
+}
+
+extension CGFloat: ValueCodingStrategy {
+    public static func decode(from decoder: Decoder) throws -> CGFloat {
+        let value = try Double(from: decoder)
+        return CGFloat(value)
+    }
+
+    public static func encode(_ value: CGFloat, to encoder: Encoder) throws {
+        try Double(value).encode(to: encoder)
+    }
+}


### PR DESCRIPTION
Added support for applying common strategies (like ValueCoder) to all properties of a type using the @Codable macro's commonStrategies parameter.

Features:
- Added HelperCoderStrategy for specifying common type conversion strategies
- Added CodableCommonStrategy for use with @Codable macro
- Added StrategyFinder to extract and apply common strategies during macro expansion
- Added comprehensive test suite for common strategies functionality

Example usage:
```swift
@Codable(commonStrategies: [.codedBy(.valueCoder())])
struct Model {
    let int: Int      // Uses ValueCoder<Int>
    let url: URL      // Uses standard Codable (not ValueCodingStrategy)
    let string: String // Uses ValueCoder<String>
}
```