### PR TITLE
Encode enum cases without associated values

### DIFF
--- a/Sources/PluginCore/Variables/Enum/Switcher/AdjacentlyTaggableSwitcher.swift
+++ b/Sources/PluginCore/Variables/Enum/Switcher/AdjacentlyTaggableSwitcher.swift
@@ -388,7 +388,7 @@ extension InternallyTaggedEnumSwitcher: AdjacentlyTaggableSwitcher {
             let switchExpr = self.encodeSwitchExpression(
                 over: location.selfValue, at: location, from: encoder,
                 in: context, withDefaultCase: location.hasDefaultCase
-            ) { name in
+            ) { name, _ in
                 let (variable, _) = identifierVariableAndKey(
                     name, withType: "_", context: context
                 )

--- a/Sources/PluginCore/Variables/Enum/Switcher/ExternallyTaggedEnumSwitcher.swift
+++ b/Sources/PluginCore/Variables/Enum/Switcher/ExternallyTaggedEnumSwitcher.swift
@@ -170,9 +170,9 @@ package struct ExternallyTaggedEnumSwitcher: TaggedEnumSwitcherVariable {
             let switchExpr = self.encodeSwitchExpression(
                 over: location.selfValue, at: location, from: contentEncoder,
                 in: context, withDefaultCase: location.hasDefaultCase
-            ) { name in
+            ) { name, hasContent in
                 """
-                let \(contentEncoder) = \(container).superEncoder(forKey: \(name))
+                let \(hasContent ? contentEncoder : "_") = \(container).superEncoder(forKey: \(name))
                 """
             }
             if let switchExpr = switchExpr {

--- a/Sources/PluginCore/Variables/Enum/Switcher/TaggedEnumSwitcherVariable.swift
+++ b/Sources/PluginCore/Variables/Enum/Switcher/TaggedEnumSwitcherVariable.swift
@@ -117,7 +117,7 @@ extension EnumSwitcherVariable {
         from coder: TokenSyntax,
         in context: some MacroExpansionContext,
         withDefaultCase default: Bool,
-        preSyntax: (TokenSyntax) -> CodeBlockItemListSyntax
+        preSyntax: ((TokenSyntax, hasContent: Bool)) -> CodeBlockItemListSyntax
     ) -> SwitchExprSyntax? {
         let cases = location.cases
         let allEncodable = cases.allSatisfy { $0.variable.encode ?? true }
@@ -144,15 +144,8 @@ extension EnumSwitcherVariable {
 
                 let generatedCode = generated.code.combined()
                 SwitchCaseSyntax(label: .case(label)) {
-                    if !generatedCode.isEmpty {
-                        CodeBlockItemListSyntax {
-                            preSyntax("\(values.first!)")
-                            generatedCode
-                        }
-                    } else {
-                        preSyntax("\(values.first!)")
-                        "break"
-                    }
+                    preSyntax(("\(values.first!)", !generatedCode.isEmpty))
+                    generatedCode.isEmpty ? "break" : generatedCode
                 }
             }
 

--- a/Sources/PluginCore/Variables/Enum/Switcher/TaggedEnumSwitcherVariable.swift
+++ b/Sources/PluginCore/Variables/Enum/Switcher/TaggedEnumSwitcherVariable.swift
@@ -150,7 +150,7 @@ extension EnumSwitcherVariable {
                             generatedCode
                         }
                     } else {
-                        "break"
+                        preSyntax("\(values.first!)")
                     }
                 }
             }

--- a/Sources/PluginCore/Variables/Enum/Switcher/TaggedEnumSwitcherVariable.swift
+++ b/Sources/PluginCore/Variables/Enum/Switcher/TaggedEnumSwitcherVariable.swift
@@ -151,6 +151,7 @@ extension EnumSwitcherVariable {
                         }
                     } else {
                         preSyntax("\(values.first!)")
+                        "break"
                     }
                 }
             }

--- a/Sources/PluginCore/Variables/Enum/Switcher/TaggedEnumSwitcherVariable.swift
+++ b/Sources/PluginCore/Variables/Enum/Switcher/TaggedEnumSwitcherVariable.swift
@@ -144,8 +144,14 @@ extension EnumSwitcherVariable {
 
                 let generatedCode = generated.code.combined()
                 SwitchCaseSyntax(label: .case(label)) {
-                    preSyntax(("\(values.first!)", !generatedCode.isEmpty))
-                    generatedCode.isEmpty ? "break" : generatedCode
+                    let preSyntax = preSyntax(("\(values.first!)", !generatedCode.isEmpty))
+                    preSyntax
+                    if !generatedCode.isEmpty {
+                        generatedCode
+                    }
+                    if preSyntax.isEmpty && generatedCode.isEmpty {
+                        "break"
+                    }
                 }
             }
 

--- a/Tests/MetaCodableTests/CodableTests.swift
+++ b/Tests/MetaCodableTests/CodableTests.swift
@@ -607,7 +607,6 @@ struct CodableTests {
                             switch self {
                             case .foo:
                                 let _ = container.superEncoder(forKey: CodingKeys.foo)
-                                break
                             }
                         }
                     }

--- a/Tests/MetaCodableTests/CodedAt/CodedAtEnumTests.swift
+++ b/Tests/MetaCodableTests/CodedAt/CodedAtEnumTests.swift
@@ -867,7 +867,6 @@ struct CodedAtEnumTests {
                             switch self {
                             case .foo:
                                 try typeContainer.encode("foo", forKey: CodingKeys.type)
-                                break
                             }
                         }
                     }

--- a/Tests/MetaCodableTests/CodedAt/CodedAtEnumTests.swift
+++ b/Tests/MetaCodableTests/CodedAt/CodedAtEnumTests.swift
@@ -880,5 +880,25 @@ struct CodedAtEnumTests {
                     """
             )
         }
+
+        @Test
+        func decodingFromJSON() throws {
+            let jsonStr = """
+                {
+                    "type": "foo"
+                }
+                """
+            let jsonData = try #require(jsonStr.data(using: .utf8))
+            let decoded = try JSONDecoder().decode(Foo.self, from: jsonData)
+            #expect(decoded == Foo.foo)
+        }
+
+        @Test
+        func encodingToJSON() throws {
+            let original = Foo.foo
+            let encoded = try JSONEncoder().encode(original)
+            let json = try JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+            #expect(json?["type"] as? String == "foo")
+        }
     }
 }

--- a/Tests/MetaCodableTests/CodedAt/CodedAtEnumTests.swift
+++ b/Tests/MetaCodableTests/CodedAt/CodedAtEnumTests.swift
@@ -802,4 +802,83 @@ struct CodedAtEnumTests {
             #expect(json["int"] as? Int == 42)
         }
     }
+
+    struct WithoutAssociatedVariables {
+        @Codable
+        @CodedAt("type")
+        enum Foo {
+            case foo
+        }
+
+        @Test
+        func expansion() throws {
+            assertMacroExpansion(
+                """
+                @Codable
+                @CodedAt("type")
+                enum Foo {
+                    case foo
+                }
+                """,
+                expandedSource:
+                    """
+                    enum Foo {
+                        case foo
+                    }
+                    
+                    extension Foo: Decodable {
+                        init(from decoder: any Decoder) throws {
+                            var typeContainer: KeyedDecodingContainer<CodingKeys>?
+                            let container = try? decoder.container(keyedBy: CodingKeys.self)
+                            if let container = container {
+                                typeContainer = container
+                            } else {
+                                typeContainer = nil
+                            }
+                            if let typeContainer = typeContainer {
+                                let typeString: String?
+                                do {
+                                    typeString = try typeContainer.decodeIfPresent(String.self, forKey: CodingKeys.type) ?? nil
+                                } catch {
+                                    typeString = nil
+                                }
+                                if let typeString = typeString {
+                                    switch typeString {
+                                    case "foo":
+                                        self = .foo
+                                        return
+                                    default:
+                                        break
+                                    }
+                                }
+                            }
+                            let context = DecodingError.Context(
+                                codingPath: decoder.codingPath,
+                                debugDescription: "Couldn't match any cases."
+                            )
+                            throw DecodingError.typeMismatch(Self.self, context)
+                        }
+                    }
+                    
+                    extension Foo: Encodable {
+                        func encode(to encoder: any Encoder) throws {
+                            let container = encoder.container(keyedBy: CodingKeys.self)
+                            var typeContainer = container
+                            switch self {
+                            case .foo:
+                                try typeContainer.encode("foo", forKey: CodingKeys.type)
+                                break
+                            }
+                        }
+                    }
+                    
+                    extension Foo {
+                        enum CodingKeys: String, CodingKey {
+                            case type = "type"
+                        }
+                    }
+                    """
+            )
+        }
+    }
 }

--- a/Tests/MetaCodableTests/IgnoreInitializedTests.swift
+++ b/Tests/MetaCodableTests/IgnoreInitializedTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import MetaCodable
 import Testing
 
@@ -124,6 +125,17 @@ struct IgnoreInitializedTests {
             case multi(_ variable: Bool, val: Int, String = "text")
         }
 
+        @Test func coding() async throws {
+            let encoded = try JSONEncoder().encode(SomeEnum.bool(false))
+            let expected = try JSONSerialization.data(withJSONObject: ["bool": [:]])
+            #expect(encoded == expected)
+            let decoded = try JSONDecoder().decode(SomeEnum.self, from: encoded)
+            switch decoded {
+            case SomeEnum.bool(true): break
+            default: Issue.record("Incorrect default value")
+            }
+        }
+
         @Test
         func expansion() throws {
             assertMacroExpansion(
@@ -232,6 +244,17 @@ struct IgnoreInitializedTests {
             @CodedAs("altString")
             case string(String)
             case multi(_ variable: Bool, val: Int, String = "text")
+        }
+
+        @Test func coding() async throws {
+            let encoded = try JSONEncoder().encode(SomeEnum.int(val: 0))
+            let expected = try JSONSerialization.data(withJSONObject: ["altInt": [:]])
+            #expect(encoded == expected)
+            let decoded = try JSONDecoder().decode(SomeEnum.self, from: encoded)
+            switch decoded {
+            case SomeEnum.int(6): break
+            default: Issue.record("Incorrect default value")
+            }
         }
 
         @Test

--- a/Tests/MetaCodableTests/IgnoreInitializedTests.swift
+++ b/Tests/MetaCodableTests/IgnoreInitializedTests.swift
@@ -185,9 +185,9 @@ struct IgnoreInitializedTests {
                             var container = encoder.container(keyedBy: CodingKeys.self)
                             switch self {
                             case .bool(_: _):
-                                break
+                                let _ = container.superEncoder(forKey: CodingKeys.bool)
                             case .int(val: _):
-                                break
+                                let _ = container.superEncoder(forKey: CodingKeys.int)
                             case .string(let _0):
                                 let contentEncoder = container.superEncoder(forKey: CodingKeys.string)
                                 try _0.encode(to: contentEncoder)
@@ -297,9 +297,9 @@ struct IgnoreInitializedTests {
                             var container = encoder.container(keyedBy: CodingKeys.self)
                             switch self {
                             case .bool(_: _):
-                                break
+                                let _ = container.superEncoder(forKey: CodingKeys.bool)
                             case .int(val: _):
-                                break
+                                let _ = container.superEncoder(forKey: CodingKeys.int)
                             case .string(let _0):
                                 let contentEncoder = container.superEncoder(forKey: CodingKeys.string)
                                 try _0.encode(to: contentEncoder)


### PR DESCRIPTION
Fixes #157

This breaks some `@IgnoreCodingInitialized` tests but that API is too confusing for me. I have no idea what it is actually supposed to do, so I can't tell if the failing tests are actually breaking the intended use. A maintainer needs to look at that.